### PR TITLE
Use cases for trust-level actions through TL4

### DIFF
--- a/scoped/README.md
+++ b/scoped/README.md
@@ -1,0 +1,24 @@
+## Use Cases
+
+Partial index of the use cases in this directory:
+
+- **sign-up** and **authentication**: account creation, login
+
+- **browse**: "read" cases, mostly: question list (including expanding a
+question), individual question, choosing a category, search
+
+- **post**: create top-level post (currently just questions), answer question, rate-limited cases of those, create tag
+
+- **edit**: suggest edit, review a suggested edit, edit directly (without review)
+
+- **comments**: reading, replying, muting a thread, moderating comments (includes deleting comments/threads, archiving threads, declining comment flags)
+
+- **vote**: just voting on posts so far; see also **flag** which includes hold votes
+
+- **flag**: flag post or comment; also contains hold/dupe-handling: suggest {hold, duplicate}, review, author response.  In file names, "-OP" means author actions, '-other" means another user seeing the question after a hold/dupe vote happened, and the base name is that initial vote.
+
+- **mod**: moderation actions at TL4 and TL5: lock, unlock, delete (more to come)
+
+
+Several use cases call for contextual help, descriptions of options, responses to user actions, etc.  The use cases include the *gist* of these bits of text, but none of that is final content.  The goal *now* is to give the designers a hint about how where we'll need roughly how much text.  The actual messages will be written later, in conjunction with the designs.
+

--- a/scoped/browse/search.md
+++ b/scoped/browse/search.md
@@ -1,0 +1,55 @@
+**Name**  
+Search
+
+----
+
+**Actor**  
+Any user
+
+----
+
+**Subject area**  
+Any page on the site
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+User sees a list of search results.
+
+----
+
+**Basic flow**
+
+User selects the search box (gives it focus).
+
+Contextual help appears, summarizing the basic search operations and linking to a help topic with more info (advanced search options).
+
+User reads the contextual help and dismisses it (or not).
+
+User types a search query and chooses a scope: search in (name of current cagegory), search in all categories.
+
+A page of posts matching the search appears.  Each post indicates its type (question, answer, wiki, etc).  If user searched all categories, results indicate category for each post.
+
+User clicks a search result and goes to that page.  If the result was an answer, the page is positioned at the answer (not the top).  User reads stuff and uses browser "back" to return to search results.
+
+User refines the search by editing the search query (which is shown on the results page).  The user's context choice is pre-selected but can be changed.  User makes changes and submits.
+
+Search results are updated.
+
+
+
+----
+
+**Notes**  
+
+Order of search results is unspecified.  Changing the order (e.g. sort by relevance, score, age...) is out of scope for MVP but will be needed later.
+
+If search results include more than one category, how categories are shown is unspecified.  Feel free to either group by category or indicate category for each result.
+
+Design note: use the right column to show expanded search help -- the info in that initial help that the user might have dismissed, plus more advanced search help.  This is the same info that was linked in the initial help.
+

--- a/scoped/browse/view-question.md
+++ b/scoped/browse/view-question.md
@@ -1,0 +1,49 @@
+**Name**  
+View individual question
+
+----
+
+**Actor**  
+Any user
+
+----
+
+**Subject area**  
+Any question page (in any category), which a user reached from a question list, from a link in a profile, from a direct link, or maybe other sources.
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+No changes from this use case specifically
+
+----
+
+**Basic flow**
+
+User is on a page for an individual question.
+
+User sees the question title, question body, tags, user card for author, link to edit history with timestamp of last edit.  If question has notices (duplicate suggestions, hold, etc) those are shown too.  Page also shows answers, sorted by score.
+
+Things user can do from here:
+
+- User chooses "summarize answers" control and page updates to show a summary view below the question and above the first answer.  This view is like the answers part of the summary shown for expand-question.md -- for each answer:
+  - up/down votes
+  - author
+  - last-modified date
+  - opening couple lines
+
+- After expanding the answer summary, user selects one of the answers to jump to it.
+
+- User scrolls through the page reading answers.
+
+- If user is TL4 or higher, user sees deleted answers.  Deleted answers are shown after all undeleted ones and, within that, in score order.  Deleted answers have some visual difference to indicate their status.
+
+- User might take actions on the page covered in other use cases (vote, flag, edit, comment, add answer).
+
+
+

--- a/scoped/comments/moderate.md
+++ b/scoped/comments/moderate.md
@@ -1,27 +1,24 @@
-**Name**
+**Name**  
 Moderate comments
 
 ----
 
-**Actor**
-User with moderator trust level.  (This use case is not about raising flags but handling them and/or deleting/locking comments/threads.)
+**Actor**  
+User with moderator trust level (TL5).  (This use case is not about raising flags but handling them and/or deleting/locking comments/threads.)
 
 ----
 
-**Subject area**
-
+**Subject area**  
 Post with comment thread(s).
 
 ----
 
-**Preconditions**
-
+**Preconditions**  
 Moderator privilege.
 
 ----
 
-**Termination outcome**
-
+**Termination outcome**  
 Comment state updated as applicable.
 
 ----
@@ -41,4 +38,8 @@ Option 2: archive thread (applies only to whole thread)
 - User clicks on "archive thread" control next to a thread (can be expanded or collapsed).
 - If this is the first time, show message: archived threads are still visible to users at trust level (whatever) but are not shown by default; if you want it to be gone, delete instead (ok/cancel).
 - Thread state changed to archived: no new replies, has some visual indicator of status when shown.
+
+Option 3: preserve comment
+- User clicks on the "decline" control next to a flagged comment.
+- Flag is dismissed and flag indicator for that comment is changed to the "not flagged" state.
 

--- a/scoped/comments/reply.md
+++ b/scoped/comments/reply.md
@@ -49,7 +49,11 @@ Case 2: reply to top-level comment where thread is collapsed (user is trusted)
 
 Case 3: user is not trusted
 - User selects "reply".
-- A message appears about not having the comment privilege yet, with a link to the help on trust levels.
+- A message appears about not having the comment privilege yet, with a link to the help on trust levels.  Special case: for TL0 the message needs to say that you don't have the privilege yet to comment on *others'* posts, because even at TL0 you can comment on your own posts.
+
+Case 4: user is TL1, so trusted but rate-limited, and has reached the daily limit:
+- User selects "reply".
+- A message appears about the daily limit on number of comments, with a link to the help on trust levels.
 
 Notifications: the following people receive a notification of the new comment:
 - person being replied to

--- a/scoped/edit/edit-directly.md
+++ b/scoped/edit/edit-directly.md
@@ -1,0 +1,36 @@
+**Name**  
+Edit post
+
+----
+
+**Actor**  
+User with TL3 (edit directly).
+
+----
+
+**Subject area**  
+Any post page (e.g. question page).  
+For editing a question that is currently on hold, see flag/edit-after-hold.md instead.
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+Edit is made; page is refreshed with updated content.
+
+----
+
+**Basic flow**
+
+- User clicks on the "edit" link for a post.
+- If editing a question that has pending hold or duplicate votes, user sees a notice pointing that out and something like "please be sure to address all issues that you can".
+- User edits qustion title, body, and/or tags or answer body (interface is the same as for creating the post in the first place).
+- User writes an edit reason in the textbox for that purpose. 
+- User chooses "submit edit" control.
+- Page refreshes.
+- If question has pending hold votes, user sees notice like "if your edit addressed the issues raised by the hold votes, consider voting to keep open".
+

--- a/scoped/edit/propose-edit.md
+++ b/scoped/edit/propose-edit.md
@@ -1,25 +1,24 @@
-**Name**
+**Name**  
 Propose edit
 
 ----
 
-**Actor**
+**Actor**  
 User with a trust level that does not support direct editing.
 
 ----
 
-**Subject area**
-
+**Subject area**  
 Any post page (e.g. question page).
 
 ----
 
-**Preconditions**
+**Preconditions**  
 None
 
 ----
 
-**Termination outcome**
+**Termination outcome**  
 Edit is submitted successfully; page is refreshed with original content and a "your edit suggestion has been submitted" message.  Message contains a link to the edit (like what reviewers would see).
 
 ----

--- a/scoped/flag/flag-comment.md
+++ b/scoped/flag/flag-comment.md
@@ -1,0 +1,47 @@
+**Name**  
+Flag a comment
+
+----
+
+**Actor**  
+Signed-in user with trust level to raise flags (TL0 for comments anywhere on own questions, TL1 for all other posts)
+
+----
+
+**Subject area**  
+Question page
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+Flag submitted (unless prevented) and user sees a "thanks for your flag" message (dismissible).
+
+----
+
+**Basic flow**
+
+User hovers over the "flag" control on a comment.
+
+User selects flag control.
+  - If user is TL0 and has reached the limit of pending flags, user sees message about that with link to help and use case ends here.  (TL0 can only flag stuff on the user's own question, so those other pending flags are already on this page -- we're not blocking the user from reporting spam elsewhere on the site.)
+
+  - Otherwise, a list of flag reasons appears with short explanations and a selector: spam, rude, not needed, other (with textbox, required).  The "not needed" case covers both obsolete comments and tangents.
+
+If user has another pending flag on this comment already, that option is grayed out and a "you have already flagged with this reason" message appears with the description.
+
+User chooses a flag reason, fills in the textbox if "other", and chooses "submit".
+
+Flag is recorded.  User receives a dismissible message along the lines of "thanks for the flag" (does not suggest commenting, unlike with post flags).
+
+
+----
+
+**Notes**
+
+We aren't preventing somebody from raising more than one flag type on a comment.  We are not supporting revoking or switching flags for MVP.
+

--- a/scoped/flag/flag-post.md
+++ b/scoped/flag/flag-post.md
@@ -1,0 +1,54 @@
+**Name**  
+Flag a post
+
+----
+
+**Actor**  
+Signed-in user with trust level to raise flags (TL0 for answers on own questions, TL1 for all other posts)
+
+----
+
+**Subject area**  
+Question page
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+Flag submitted (unless prevented) and user sees a "thanks for your flag" message (dismissible).
+
+----
+
+**Basic flow**
+
+User hovers over the "flag" control on a post and sees a tooltip explaining what flags are for.
+
+User selects flag control.
+  - If user is TL0 and has reached the limit of pending flags, user sees message about that with link to help and use case ends here.  (TL0 can only flag stuff on the user's own question, so those other pending flags are already on this page -- we're not blocking the user from reporting spam elsewhere on the site.)
+
+  - Otherwise, a list of flag reasons appears with short explanations and a selector.  The reasons vary by context:
+
+    - For an answer: spam, rude, does not answer the question (message should include something to the effect of "don't flag for being wrong"), other (with textbox, required)
+    - For a question: spam, rude, needs author's attention, off topic, other (with textbox, required)
+
+If user has another pending flag on this post already, that option is grayed out and a "you have already flagged with this reason" message appears with the description.
+
+User chooses a flag reason, fills in the textbox if "other", and chooses "submit".
+
+Flag is recorded.  User receives a dismissible message along the lines of "thanks for the flag, and if you can suggest ways to improve this post, please leave a comment".
+
+
+----
+
+**Notes**
+
+Duplicates are not included in question flags; see duplicate.md.
+
+The "needs attention" and "off topic" post flags don't include sub-reasons like for hold votes, but the short explanations should cover those cases.  See hold.
+
+We aren't preventing somebody from raising more than one flag type on a post.  We are not supporting revoking or switching flags for MVP.
+

--- a/scoped/mod/delete-post-tl4.md
+++ b/scoped/mod/delete-post-tl4.md
@@ -1,0 +1,55 @@
+**Name**  
+Delete post (TL4)
+
+----
+
+**Actor**  
+Signed-in user with TL4 (deputy)
+
+----
+
+**Subject area**  
+Any post (see preconditions)
+
+----
+
+**Preconditions**  
+Post must be eligible for deletion at this level; one of:
+  - answers below some score threshold
+  - questions that have been on hold for more than N days
+  - posts with spam or rude flags
+
+
+----
+
+**Termination outcome**  
+Post is deleted (see details below).
+
+
+----
+
+**Basic flow**  
+
+User sees a post and (if there are flags) an indicator of outstanding flags.  Outstanding flags work as for the lock case.
+
+User decides post should be deleted.  User chooses "moderate" control and, from there, chooses "delete".  (If the post is not eligible for deletion, this option isn't selectable and there's a short message with the option explaining why not.)
+
+User chooses "apply" (or whatever we call it) to complete the deletion.  The following things happen:
+
+- Post is not visible to those below this TL (except the author can always see).
+- The post is rendered in a way that indicates deleted status, for those who casn see deleted posts.
+- A notice is added to the post saying who deleted it and when.
+- Deletion is added to post history.
+
+
+----
+
+**Notes**  
+
+We haven't specified community deletions yet, so I put the control on the "moderate" menu.  If we do community delete votes later we should move this control for consistency.
+
+Should deletions by TL4 users emit flags to TL5 (elected mods)?
+
+Should outstanding spam or rude flags be auto-resolved?
+
+

--- a/scoped/mod/delete-post-tl5.md
+++ b/scoped/mod/delete-post-tl5.md
@@ -1,0 +1,45 @@
+**Name**  
+Delete post (TL5)
+
+----
+
+**Actor**  
+Signed-in user with TL5 (elected moderator)
+
+----
+
+**Subject area**  
+Any post (see preconditions)
+
+----
+
+**Preconditions**  
+None.  Moderators can delete anything.
+
+
+----
+
+**Termination outcome**  
+Post is deleted (see details below).
+
+
+----
+
+**Basic flow**  
+
+User sees a post and (if there are flags) an indicator of outstanding flags.  Outstanding flags work as for the lock case.
+
+User decides post should be deleted.  User chooses "moderate" control and, from there, chooses "delete".
+
+User chooses "apply" (or whatever we call it) to complete the deletion.  Outcome is the same as for delete-post-tl4.md.
+
+
+----
+
+**Notes**  
+
+We haven't specified community deletions yet, so I put the control on the "moderate" menu.  If we do community delete votes later we should move this control for consistency.
+
+Should outstanding spam or rude flags be auto-resolved?
+
+

--- a/scoped/mod/lock-tl4.md
+++ b/scoped/mod/lock-tl4.md
@@ -1,0 +1,65 @@
+**Name**  
+Lock post (TL4)
+
+----
+
+**Actor**  
+Signed-in user with TL4 (deputy)
+
+----
+
+**Subject area**  
+Any post
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+Page updated with lock changes (depending on lock type).  
+Change logged in post history, with attribution.  
+Flag is automatically raised (if you're willing to lock you should be willing to flag).
+
+
+----
+
+**Basic flow**
+
+User sees a post and (if there are flags) an indicator of outstanding flags.
+
+User selects the "outstanding flags" indicator and sees a summary of the types and numbers of flags raised, excluding "other" flags and their text but including comment flags as one group.  (Example: "3 spam, 2 rude, 1 off-topic, 12 comment flags".)
+
+User reviews post and/or comments and decides there's a problem.  User chooses "moderate" control and, from there, chooses "lock".
+
+User sees an in-page dialogue for lock type (checkboxes) and duration.  Each lock type is accompanied by a short description of what it does.  Duration is 1, 2, or 3 days.  Types are:
+  - no new comments
+  - content lock (no new edits)
+
+User chooses one or more types and a duration.  The following things happen:
+
+  - The post is locked in the specified way(s).
+  - A notice about the lock is added, focusing on what is blocked (for example, "this post is not accepting comments at this time").
+  - For users at TL4 or higher only, the notice includes when the lock will expire.
+  - The lock is added to the post history (type and who locked, not duration).
+  - A flag about the lock is automatically raised for mod (TL5) attention.
+  - If user applied a comment lock, a notice appears saying something like "remember to flag any inappropriate comments".
+
+
+----
+
+**Notes**  
+
+When/if we add auto-flags, these would be included (for example, "N edits in 24 hours", "rollback war", "N edits by one person".)
+
+Any other lock types we want to make available to users at this level?  (TL4 is one level below elected moderators.)
+
+Max duration is 3 days because that should allow enough time for moderator review, but do we need to allow longer?  Do we want to allow users at this level to perma-lock posts (subject to unlocking by others)?
+
+Historical locks are excluded here.
+
+Locks do not block voting.
+
+Locks do not block new answers.  If you think a question should be closed, vote for that.

--- a/scoped/mod/lock-tl5.md
+++ b/scoped/mod/lock-tl5.md
@@ -1,0 +1,57 @@
+**Name**  
+Lock post (TL5, moderator)
+
+----
+
+**Actor**  
+Signed-in user with TL5 (elected moderator)
+
+----
+
+**Subject area**  
+Any post
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+Page updated with lock changes (depending on lock type).  
+Change logged in post history, with attribution.  
+Any pending lock flags from TL4 users are resolved.  
+
+
+----
+
+**Basic flow**
+
+User sees a post, either locked or normal, and (if there are flags) an indicator of outstanding flags.  (Moderators see the flags indicator on all posts.)
+
+User selects the "outstanding flags" indicator and sees an in-page list of the flags.  If the post was locked by a TL4 user, this includes the auto-flag for the lock.  (The mod flags interface is described more in mod/see-flags.md.)
+
+User reviews everything and decides to lock the post.  As at TL4, user chooses "moderate" control and, from there, "lock". If post is already locked, option is "modify lock" (see unlock.md for details).
+
+The interface for specifying a lock is the same as at TL4 except that there is a new duration, "permanent".
+
+User chooses type(s) and duration.  Outcomes are the same as at TL4 except no auto-flag is raised and any pending lock flags are resolved.
+
+
+**Alternate flows**  
+
+- User decides to delete the post instead.  See the delete use case.
+- User decides a locked post should not be locked.  See the unlock use case.
+
+
+----
+
+**Notes**  
+
+The flag interface is basically "Monica's Flag ToC" userscript: https://github.com/Shog9/flagtools.
+
+Should there be any new lock types for TL5? 
+
+
+

--- a/scoped/mod/unlock.md
+++ b/scoped/mod/unlock.md
@@ -1,0 +1,57 @@
+**Name**  
+Unlock post (TL5, moderator)
+
+----
+
+**Actor**  
+Signed-in user with TL5 (elected moderator)
+
+----
+
+**Subject area**  
+Any locked post
+
+----
+
+**Preconditions**  
+None
+
+----
+
+**Termination outcome**  
+Page updated to remove lock.  
+Change logged in post history, with attribution.  
+Any pending lock flags from TL4 users are declined.
+
+
+----
+
+**Basic flow**
+
+User sees a post that is locked and disagrees.
+
+User chooses "moderate" control and, from there, "modify lock".
+
+User sees the same lock dialogue as for locking a post; locks currently in place have their checkboxes checked.
+
+User unchecks lock(s) to be removed.  (User could also choose other lock types here to change the lock, but that's not this use case.)
+
+User chooses "change lock" or "done" or whatever we call that control.  The following things happen:
+
+- The post is unlocked in the specified way(s).
+- The notice is removed.  (If only some locks were removed, the notice is adjusted instead.)
+- The unlocking is added to the post history (type and who unlocked).
+
+
+----
+
+**Notes**  
+
+The flag interface is basically "Monica's Flag ToC" userscript: https://github.com/Shog9/flagtools.
+
+Should there be any new lock types for TL5? 
+
+This use case doesn't try to automatically handle any pending lock flags.  The user ought to explain the outcome to the flagger anyway.
+
+
+

--- a/scoped/post/answer-rate-limited.md
+++ b/scoped/post/answer-rate-limited.md
@@ -1,0 +1,38 @@
+**Name**  
+Answer question when rate-limited
+
+----
+
+**Actor**  
+Signed-in user
+
+----
+
+**Subject area**  
+Any question page that is accepting answers (not closed, locked, etc).
+
+
+----
+
+**Preconditions**  
+User is TL0 or TL1.
+
+----
+
+**Termination outcome**  
+User is on original page.
+
+----
+
+**Basic flow**
+
+The flow here is the same as for ask-rate-limited.md, except that the entry point is the "add answer" button, not the "ask question" button. 
+
+----
+
+**Notes**
+
+The notes from ask-rate-limited.md apply here too.
+
+The rate limits are different for questions and answers.
+

--- a/scoped/post/ask-rate-limited.md
+++ b/scoped/post/ask-rate-limited.md
@@ -1,0 +1,46 @@
+**Name**  
+Ask question when rate-limited
+
+----
+
+**Actor**  
+Signed-in user
+
+----
+
+**Subject area**  
+Any page in a category that accepts questions (Q&A, Meta, others defined by the site).
+
+----
+
+**Preconditions**  
+User is TL0 or TL1.
+
+----
+
+**Termination outcome**  
+User is on original page.
+
+----
+
+**Basic flow**
+
+- User clicks on "ask question" button.
+
+- If user has reached limit for questions/day:
+    - User sees notice like "You've already asked N questions today and can ask a new question again in N hours.  In the meantime, please address any responses you've received on your other questions (link).  For more information on rate limits see (help link). (friendly closing)"
+    - User clicks on one of those links for more info, or dismisses the notice.
+
+- If user has not reached limit for questions/day but has reached the time-based rate limit:
+    - User sees notice like "Please wait (N minutes) after your last question before asking another.  In the meantime (...).  For more info (...). (friendly closing)"
+    - User clicks on one of those links for more info, or dismisses the notice.
+
+
+----
+
+**Notes**
+
+Intercept the attempted question as early as possible -- when the user starts, not when the user has already written a question and tries to submit it.  Not only is this less frustrating for the user, but it means we don't have to implement a "save draft for later" flow.
+
+For the back end: what's the earliest point where we could catch this if the user were to bypass the "ask" button and use a direct URL?  How do we block that? 
+

--- a/scoped/post/create-post.md
+++ b/scoped/post/create-post.md
@@ -1,25 +1,25 @@
-**Name**
+**Name**  
 Create post
 
 ----
 
-**Actor** 
+**Actor**  
 Signed-in user
 
 ----
 
-**Subject area**
+**Subject area**  
 Any
 
 ----
 
-**Preconditions** 
+**Preconditions**  
 User is signed in and permitted to post (TL2+, or TL0/1 and not
 rate-limited).
 
 ----
 
-**Termination outcome**
+**Termination outcome**  
 User is on question/post page for the now-posted item.
 
 ----

--- a/scoped/post/create-tag.md
+++ b/scoped/post/create-tag.md
@@ -1,0 +1,50 @@
+**Name**  
+Create tag 
+
+----
+
+**Actor**  
+Signed-in user at TL3 or higher.
+
+----
+
+**Subject area**  
+Any create or edit page for any post type that has tags.
+
+----
+
+**Preconditions**  
+New tag is created.
+
+----
+
+**Termination outcome**  
+User is on same page with new tag added.
+
+----
+
+**Basic flow**
+
+- For a user with TL3, there is a "create tag" control next to the tag area of the edit interface.
+
+- User selects the control.
+
+- An in-page dialogue prompts for the tag name (required) and short description (optional but encouraged).  This dialogue includes something like "new tag in (category name)", to gently remind the person what part of the site we're in.
+
+- User types a tag name.  Similar tag names are shown.  The user might dismiss the dialogue at this point and choose to use an existing tag instead.
+
+- User clicks into the description textbox and contextual help appears with basic guidance (a sentence or so).
+
+- User types a description and then chooses "create tag" button.
+
+- Tag is created and added to the question being edited.
+
+
+----
+
+**Notes**
+
+Tag creation is an explicit act; you can't create a tag just by typing its name while editing tags in a question.  This should cut down on typo-tags.
+
+We prompt for a short description at tag-creation time to reduce the chances of having "what the heck is this tag for?" queries from other users.  However, we'll make entering it optional, so people who can't write a decent description don't just mash the keyboard to get past the dialogue.
+

--- a/scoped/vote/vote-post.md
+++ b/scoped/vote/vote-post.md
@@ -1,25 +1,25 @@
-**Name**
+**Name**  
 Vote on a post
 
 ----
 
-**Actor**
-Any signed-in user 
+**Actor**  
+Any signed-in user  
 (reminder: TL0 to upvote answers to own question, TL1 to upvote, TL2 to downvote)
 
 ----
 
-**Subject area**
+**Subject area**  
 Individual question page.
 
 ----
 
-**Preconditions**
+**Preconditions**  
 None (privilege and already-voted cases are addressed in the flow section).
 
 ----
 
-*Termination outcome**
+**Termination outcome**  
 Vote is recorded and shown on the page.
 
 ----


### PR DESCRIPTION
Adds/updates use cases for the various "can do X" actions listed for trust levels 0 through 4, where not already present.  There's a little from TL5 as well, where there were interactions with lower trust levels.  (For example, locking behaves a little differently at TL4 and TL5.)

I generated this list from the TL spec (https://github.com/codidact/docs/wiki/User-Privileges).  Not all use cases are listed as privileges, so this isn't everything users can do.
